### PR TITLE
ops: Add type check step to CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,27 @@ on:
     branches: [main]
 
 jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Run Typechecker
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm tc
+
   lint:
     runs-on: ubuntu-latest
 
@@ -23,7 +44,6 @@ jobs:
           cache: "pnpm"
 
       - name: Run Linter
-
         run: |
           pnpm install --frozen-lockfile
           pnpm lint

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -43,4 +43,37 @@ export default tseslint.config(
     linterOptions: { reportUnusedDisableDirectives: true },
     languageOptions: { parserOptions: { projectService: true } },
   },
+  {
+    ignores: ["src/db/**/*.ts", "src/db/**/*.tsx"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "@prisma/client",
+              message: "Please import via `@/db` as appropriate",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    ignores: ["src/components/ui/**/*.ts", "src/components/ui/**/*.tsx"],
+    rules: {
+      "no-restricted-imports": [
+        "warn",
+        {
+          patterns: [
+            {
+              group: ["@radix-ui/*"],
+              message:
+                "Imports directly from radix-ui are generally incorrect; please check and ignore this if necessary",
+            },
+          ],
+        },
+      ],
+    },
+  },
 );


### PR DESCRIPTION
Very tiny PR that does 2 things:

1) I realised you were totally right - we do need a separate typecheck step in the CI, because we don't build for feature branches but that doesn't mean we shouldn't typecheck.
2) I enabled some extra ESLint rules (specifically around restricting imports). 

I think num. 2 there has already proven it's value - the rule picks up 2 places where we are importing from radix ui instead of `@/components`
